### PR TITLE
Bugfix in orca engine when ordering scan TS files

### DIFF
--- a/spycci/engines/orca.py
+++ b/spycci/engines/orca.py
@@ -1441,7 +1441,7 @@ class OrcaInput(Engine):
                             else:
                                 break
 
-                mol_list = []
+                indexed_mol_list = []
                 for xyz in xyz_list:
                     if xyz.endswith(".refined.xyz"):
                         continue
@@ -1450,9 +1450,10 @@ class OrcaInput(Engine):
                     shutil.copy(f"input.{index}.xyz", f"{mol.name}.{index}.xyz")
                     system = System(f"{mol.name}.{index}.xyz", charge=mol.charge, spin=mol.spin)
                     system.properties.set_electronic_energy(energies[int(index) - 1], self)
-                    mol_list.append(system)
+                    indexed_mol_list.append([index, system])
 
-                ensemble = Ensemble(mol_list)
+                indexed_mol_list.sort(key = lambda v: v[0])
+                ensemble = Ensemble([x[1] for x in indexed_mol_list])
 
                 shutil.move("input.xyz", f"{mol.name}_TS.xyz")
                 newmol = System(f"{mol.name}_TS.xyz", charge=mol.charge, spin=mol.spin)


### PR DESCRIPTION
Bugfix in `scanTS` method of the `OrcaInput` engine: when processing the `.xyz` files associated with the scan frames, the loading order was based on the file reading order and was, as such, system-dependent. 

Now the index of the frame is used to sort the `System` objects list before initializing the `Ensemble` object, ensuring the correct ordering of frames in the `Ensemble`.