### PR TITLE
pypi deploy workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,37 @@
+name: Upload SPyCCI Python Package to PyPI when a Release is Published
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/spycci-toolkit
+    permissions:
+      id-token: write 
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build the package
+        run: |
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,10 +15,10 @@ jobs:
       id-token: write 
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -1,0 +1,35 @@
+name: Manual Publish to TestPyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build the package
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "spycci"
+name = "spycci-toolkit"
 version = "0.0.1"
 description = "Simple Python Computational Chemistry Interface"
 readme = "README.md"
@@ -29,3 +29,7 @@ testing = [
 
 [tool.flake8]
 max-line-length = 160
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["spycci"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy
+numpy>=2.2.6
 pandas>=1.3.0
-sh
-rdkit
-morfeus-ml
-matplotlib
+sh>=2.2.2
+rdkit>=2025.3.3
+morfeus-ml>=0.7.2
+matplotlib>=3.10.3


### PR DESCRIPTION
Apparently `spycci` is not available sa a package name due to similarity with existing packages. I think that the cleanest way to obtain a good looking result is to publish under `spycci-toolkit` name and keep `spycci` as the root name.

The package can be installed with `pip install spycci-toolkit` but then in the library the syntax `from spyccy import ...` still holds.

I found the documentation quite confusing but I came up with the solution in this pull request. I configured both the workflow for automatic deploy on release to PyPI and for manual release on Test-PyPI. I think we shuld use the latter to test the feasibility of what stated above.

@AresValley and @lbabetto  what do you think?

If merged should close #3 