### PR TITLE
Add CI with full test suite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+__pycache__
+*.pyc
+dist
+build
+.eggs
+.mypy_cache
+pytest_cache
+.cache
+.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build test image
+        run: |
+          docker build \
+            --secret id=gh_token,env=ORCA_PAT \
+            -t ghcr.io/${{ github.repository_owner }}/spycci-ci:${{ github.sha }} \
+            .
+        env:
+          ORCA_PAT: ${{ secrets.ORCA_PAT }}
+      - name: Run pytest inside container
+        run: docker run --rm ghcr.io/${{ github.repository_owner }}/spycci-ci:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ ENV PATH=/opt/orca/bin:${XTBHOME}/bin:${CREST_BIN}:\
 ENV LD_LIBRARY_PATH=/opt/conda/envs/spycci/lib:/opt/orca/lib:$LD_LIBRARY_PATH
 ENV OMPI_MCA_plm=isolated
 ENV OMPI_MCA_rmaps_base_oversubscribe=1
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 ENV PYTHONUNBUFFERED=1
 
 RUN useradd -m -s /bin/bash spyccitest && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1.7
+FROM condaforge/mambaforge:24.9.2-0
+SHELL ["/bin/bash","-o","pipefail","-c"]
+
+# --- base system + tooling ---------------------------------------------------
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget ca-certificates tar xz-utils curl jq && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- conda env ---------------------------------------------------------------
+COPY environment.yml /tmp/
+RUN mamba env create -f /tmp/environment.yml && mamba clean -afy
+ENV CONDA_DEFAULT_ENV=spycci
+ENV PATH=/opt/conda/envs/spycci/bin:$PATH
+
+# --- project sources ---------------------------------------------------------
+WORKDIR /workspace
+COPY . /workspace
+RUN pip install --no-cache-dir -e .
+
+# --- DFTB+ parameters --------------------------------------------------------
+ENV DFTBPLUS_PARAM_DIR=/opt/dftbplus/slakos
+RUN mkdir -p "${DFTBPLUS_PARAM_DIR}" && \
+    wget -q https://github.com/dftbparams/3ob/releases/download/v3.1.0/3ob-3-1.tar.xz -O /tmp/3ob.tar.xz && \
+    tar -xf /tmp/3ob.tar.xz -C "${DFTBPLUS_PARAM_DIR}" && rm /tmp/3ob.tar.xz
+
+# --- ORCA (private release asset) -------------------------------------------
+ARG ORCA_OWNER=hbar-team
+ARG ORCA_REPO=orca-binaries
+ARG ORCA_TAG=v6.1.0-f.0
+ARG ORCA_ASSET=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz
+RUN --mount=type=secret,id=gh_token \
+    set -euo pipefail; \
+    GH_TOKEN="$(cat /run/secrets/gh_token)"; \
+    release_json=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+                          "https://api.github.com/repos/${ORCA_OWNER}/${ORCA_REPO}/releases/tags/${ORCA_TAG}"); \
+    asset_api=$(echo "$release_json" | jq -r --arg NAME "$ORCA_ASSET" '.assets[]? | select(.name==$NAME) | .url'); \
+    [ -n "$asset_api" ] && [ "$asset_api" != "null" ] || { echo "Asset $ORCA_ASSET not found"; exit 1; }; \
+    curl -sL -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/octet-stream" \
+         "$asset_api" -o /tmp/orca.tar.xz; \
+    mkdir -p /opt/orca && \
+    tar -xf /tmp/orca.tar.xz -C /opt/orca --strip-components=1 2>/dev/null || \
+    tar -xf /tmp/orca.tar.xz -C /opt/orca; \
+    rm /tmp/orca.tar.xz; \
+    chmod -R a+rx /opt/orca; \
+    find /opt/orca -maxdepth 3 -type f -name orca -perm -u+x -print -quit
+
+# --- XTB (official binary) ---------------------------------------------------
+ENV XTBHOME=/opt/xtb
+RUN wget -q https://github.com/grimme-lab/xtb/releases/download/v6.6.1/xtb-6.6.1-linux-x86_64.tar.xz && \
+    tar -xf xtb-6.6.1-linux-x86_64.tar.xz && \
+    mv xtb-6.6.1 "${XTBHOME}" && \
+    rm xtb-6.6.1-linux-x86_64.tar.xz
+
+# --- CREST (official binary) -------------------------------------------------
+ENV CREST_BIN=/opt/crest
+RUN wget -q https://github.com/crest-lab/crest/releases/download/v3.0.2/crest-gnu-12-ubuntu-latest.tar.xz && \
+    tar -xf crest-gnu-12-ubuntu-latest.tar.xz && \
+    mv crest "${CREST_BIN}" && \
+    rm crest-gnu-12-ubuntu-latest.tar.xz && \
+    chmod +x ${CREST_BIN}/crest
+
+# --- runtime env + user ------------------------------------------------------
+ENV ORCA_ROOT=/opt/orca
+ENV PATH=/opt/orca/bin:${XTBHOME}/bin:${CREST_BIN}:\
+/opt/conda/envs/spycci/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/conda/envs/spycci/lib:/opt/orca/lib:$LD_LIBRARY_PATH
+ENV OMPI_MCA_plm=isolated
+ENV OMPI_MCA_rmaps_base_oversubscribe=1
+ENV PYTHONUNBUFFERED=1
+
+RUN useradd -m -s /bin/bash spyccitest && \
+    chown -R spyccitest:spyccitest /workspace /opt/conda/envs/spycci \
+    ${ORCA_ROOT} ${XTBHOME} ${CREST_BIN} ${DFTBPLUS_PARAM_DIR} 
+USER spyccitest
+WORKDIR /workspace
+
+CMD ["pytest","-vvv","--color=yes"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ ENV LD_LIBRARY_PATH=/opt/conda/envs/spycci/lib:/opt/orca/lib:$LD_LIBRARY_PATH
 ENV OMPI_MCA_plm=isolated
 ENV OMPI_MCA_rmaps_base_oversubscribe=1
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+ENV OMPI_MCA_btl=^openib
 ENV PYTHONUNBUFFERED=1
 
 RUN useradd -m -s /bin/bash spyccitest && \
@@ -75,4 +76,4 @@ RUN useradd -m -s /bin/bash spyccitest && \
 USER spyccitest
 WORKDIR /workspace
 
-CMD ["pytest","-vvv","--color=yes","-ra","--maxfail=0"]
+CMD ["pytest","-vvv","--color=yes"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ RUN useradd -m -s /bin/bash spyccitest && \
 USER spyccitest
 WORKDIR /workspace
 
-CMD ["pytest","-vvv","--color=yes","ra","--maxfail=0"]
+CMD ["pytest","-vvv","--color=yes","-ra","--maxfail=0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ SHELL ["/bin/bash","-o","pipefail","-c"]
 
 # --- base system + tooling ---------------------------------------------------
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget ca-certificates tar xz-utils curl jq && \
+    apt-get install -y --no-install-recommends wget ca-certificates tar zip xz-utils curl jq && \
     rm -rf /var/lib/apt/lists/*
 
 # --- conda env ---------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ RUN useradd -m -s /bin/bash spyccitest && \
 USER spyccitest
 WORKDIR /workspace
 
-CMD ["pytest","-vvv","--color=yes"]
+CMD ["pytest","-vvv","--color=yes","-ra","--maxfail=0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ RUN useradd -m -s /bin/bash spyccitest && \
 USER spyccitest
 WORKDIR /workspace
 
-CMD ["pytest","-vvv","--color=yes"]
+CMD ["pytest","-vvv","--color=yes","ra","--maxfail=0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,11 @@ RUN --mount=type=secret,id=gh_token \
     set -euo pipefail; \
     GH_TOKEN="$(cat /run/secrets/gh_token)"; \
     release_json=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
-                          "https://api.github.com/repos/${ORCA_OWNER}/${ORCA_REPO}/releases/tags/${ORCA_TAG}"); \
+    "https://api.github.com/repos/${ORCA_OWNER}/${ORCA_REPO}/releases/tags/${ORCA_TAG}"); \
     asset_api=$(echo "$release_json" | jq -r --arg NAME "$ORCA_ASSET" '.assets[]? | select(.name==$NAME) | .url'); \
     [ -n "$asset_api" ] && [ "$asset_api" != "null" ] || { echo "Asset $ORCA_ASSET not found"; exit 1; }; \
     curl -sL -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/octet-stream" \
-         "$asset_api" -o /tmp/orca.tar.xz; \
+    "$asset_api" -o /tmp/orca.tar.xz; \
     mkdir -p /opt/orca && \
     tar -xf /tmp/orca.tar.xz -C /opt/orca --strip-components=1 2>/dev/null || \
     tar -xf /tmp/orca.tar.xz -C /opt/orca; \
@@ -62,8 +62,7 @@ RUN wget -q https://github.com/crest-lab/crest/releases/download/v3.0.2/crest-gn
 
 # --- runtime env + user ------------------------------------------------------
 ENV ORCA_ROOT=/opt/orca
-ENV PATH=/opt/orca/bin:${XTBHOME}/bin:${CREST_BIN}:\
-/opt/conda/envs/spycci/bin:$PATH
+ENV PATH=/opt/orca/bin:${XTBHOME}/bin:${CREST_BIN}:/opt/conda/envs/spycci/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/conda/envs/spycci/lib:/opt/orca/lib:$LD_LIBRARY_PATH
 ENV OMPI_MCA_plm=isolated
 ENV OMPI_MCA_rmaps_base_oversubscribe=1

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: spycci
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - dftbplus=24.1=mpi_openmpi_*
+  - packmol=21.1.0
+  - openbabel=3.1.1
+  - pytest
+  - pip

--- a/tests/integration/test_dftbplus_integration.py
+++ b/tests/integration/test_dftbplus_integration.py
@@ -21,7 +21,7 @@ TEST_DIR = dirname(abspath(__file__))
 def test_DFTBInput___init__():
 
     try:
-        engine = DFTBInput(parallel="mpi")
+        engine = DFTBInput(parameters="3ob-3-1", parallel="mpi")
 
     except:
         assert False, "Unenxpected exception raised during DFTBInput class construction"
@@ -37,7 +37,7 @@ def test_DFTBInput___init__():
 # Test the spe() function on a water molecule in vacuum
 def test_DFTBInput_spe():
 
-    engine = DFTBInput(parallel="mpi")
+    engine = DFTBInput(parameters="3ob-3-1", parallel="mpi")
     mol = System.from_xyz(f"{TEST_DIR}/utils/xyz_files/water.xyz")
 
     try:
@@ -58,7 +58,7 @@ def test_DFTBInput_spe():
 # Test the spe() function on a water molecule in vacuum with no inplace option
 def test_DFTBInput_spe_no_inplace():
 
-    engine = DFTBInput(parallel="mpi")
+    engine = DFTBInput(parameters="3ob-3-1", parallel="mpi")
     mol = System.from_xyz(f"{TEST_DIR}/utils/xyz_files/water.xyz")
 
     try:
@@ -79,7 +79,7 @@ def test_DFTBInput_spe_no_inplace():
 # Test the opt() function on a water molecule in vacuum
 def test_DFTBInput_opt():
 
-    engine = DFTBInput(parallel="mpi")
+    engine = DFTBInput(parameters="3ob-3-1", parallel="mpi")
     mol = System.from_xyz(f"{TEST_DIR}/utils/xyz_files/water.xyz")
 
     try:
@@ -108,7 +108,7 @@ def test_DFTBInput_opt():
 # Test the opt() function on a water molecule in vacuum with no inplace option
 def test_DFTBInput_opt_no_inplace():
 
-    engine = DFTBInput(parallel="mpi")
+    engine = DFTBInput(parameters="3ob-3-1", parallel="mpi")
     mol = System.from_xyz(f"{TEST_DIR}/utils/xyz_files/water.xyz")
 
     try:
@@ -137,7 +137,7 @@ def test_DFTBInput_opt_no_inplace():
 # Test the md_nvt() function on a water molecule in vacuum
 def test_DFTBInput_md_nvt():
 
-    engine = DFTBInput(parallel="mpi")
+    engine = DFTBInput(parameters="3ob-3-1", parallel="mpi")
     mol = System.from_xyz(f"{TEST_DIR}/utils/xyz_files/water.xyz")
 
     try:
@@ -157,7 +157,7 @@ def test_DFTBInput_md_nvt():
 # Test the simulated_annealing() function on a water molecule in vacuum
 def test_DFTBInput_simulated_annealing():
 
-    engine = DFTBInput(parallel="mpi")
+    engine = DFTBInput(parameters="3ob-3-1", parallel="mpi")
     mol = System.from_xyz(f"{TEST_DIR}/utils/xyz_files/water.xyz")
 
     try:
@@ -193,7 +193,7 @@ def test_DFTBInput_simulated_annealing():
 # Test the simulated_annealing() function on a water molecule in vacuum with no inplace option
 def test_DFTBInput_simulated_annealing_no_inplace():
 
-    engine = DFTBInput(parallel="mpi")
+    engine = DFTBInput(parameters="3ob-3-1", parallel="mpi")
     mol = System.from_xyz(f"{TEST_DIR}/utils/xyz_files/water.xyz")
 
     try:

--- a/tests/integration/test_dftbplus_integration.py
+++ b/tests/integration/test_dftbplus_integration.py
@@ -30,7 +30,7 @@ def test_DFTBInput___init__():
         assert engine.method == "DFTB"
         assert (
             engine.level_of_theory
-            == "DFTBInput || method: DFTB | parameters: 3ob/3ob-3-1 | 3rd order: True | dispersion: False"
+            == "DFTBInput || method: DFTB | parameters: 3ob-3-1 | 3rd order: True | dispersion: False"
         )
 
 


### PR DESCRIPTION
This PR adds a CI workflow which runs all the tests via a Docker container.

The container features all the current third-party software requirements (new ones can easily be added via the Dockerfile), specifically:

- A Conda environment with Python 3.12
- DFTB+ 24.1, OpenMPI version (installed via conda)
- OpenMPI 4.1.6 (conda-forge)
- Crest 3.0.2 (precompiled GNU binaries)
- xTB 6.6.1 (precompiled binaries)
- Packmol 21.1.0 (conda-forge)
- Openbabel 3.1.1 (conda-forge)
- Orca 6.1.0-f.0 (see below)

The Orca binaries are installed with this procedure:

1. The .tar.xz was downloaded from the Orca website, and uploaded to the [orca-binaries](https://github.com/hbar-team/orca-binaries) private repo owned by Hbar-team
2. A fine-grained access token was generated, with read-only access to that private repo, and stored as a secret in the Spycci repo.
3. The Docker container is built in CI, which has access to the secret token, with no way external users should be able to intercept it (Orca is free for download, but we are not allowed to redistribute it, so we cannot host the full container publicly)
4. During build, the container downloads the archive from the private repo and installs it
5. CI runs all the tests, then deletes the container after completion

This ensures all tests are run with the same exact software stack and automates the testing procedure. Currently this is active on all pushes and pull requests, but we should probably limit this to pull requests only to avoid overloading the GH workers (the whole thing takes about 15 minutes for each run).

I was also thinking of providing an alternative way to build the container locally (ci version is tagged as `spycci:ci`, this could be something like `spycci:local`) by providing the Orca archive manually, this way anyone with a valid installation of Orca can build the container to run the test suite locally for development.

There are a couple of tests which currently fail, but those are the usual "xtb gives a slightly different output based on the version" issue, which should get fixed with #40 

Let me know what you think!