### PR TITLE
add: singularity support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ main.py
 *.tar.bz2
 *.tar.xz
 *.zip
+*.sif
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ARG ORCA_REPO=orca-binaries
 ARG ORCA_TAG=v6.1.0-f.0
 ARG ORCA_ASSET=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz
 ARG ORCA_LOCAL_ARCHIVE=
-COPY ${ORCA_LOCAL_ARCHIVE} /tmp/orca.tar.xz
+COPY ${ORCA_LOCAL_ARCHIVE}* /tmp/orca.tar.xz
 RUN --mount=type=secret,id=gh_token,required=0 \
     set -euo pipefail; \
     TOKEN_FILE="/run/secrets/gh_token"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ARG ORCA_OWNER=hbar-team
 ARG ORCA_REPO=orca-binaries
 ARG ORCA_TAG=v6.1.0-f.0
 ARG ORCA_ASSET=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz
-ARG ORCA_LOCAL_ARCHIVE=
+ARG ORCA_LOCAL_ARCHIVE=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz
 COPY ${ORCA_LOCAL_ARCHIVE}* /tmp/orca.tar.xz
 RUN --mount=type=secret,id=gh_token,required=0 \
     set -euo pipefail; \

--- a/apptainer.def
+++ b/apptainer.def
@@ -34,7 +34,7 @@ From: condaforge/mambaforge:24.9.2-0
     rm /tmp/3ob.tar.xz
 
     # Install ORCA
-    ORCA_TMP="/tmp/orca.tar.xz"
+    ORCA_TMP="/workspace/orca.tar.xz"
     mkdir -p /opt/orca
     tar -xf "${ORCA_TMP}" -C /opt/orca --strip-components=1 2>/dev/null || \
         tar -xf "${ORCA_TMP}" -C /opt/orca

--- a/apptainer.def
+++ b/apptainer.def
@@ -1,0 +1,90 @@
+Bootstrap: docker
+From: condaforge/mambaforge:24.9.2-0
+
+%labels
+    Author hbar-team
+    Description SPyCCI Apptainer image with ORCA, XTB, CREST, and DFTB parameters
+
+%files
+    environment.yml /workspace/environment.yml
+    spycci /workspace/spycci
+    tests /workspace/tests
+    pyproject.toml /workspace/pyproject.toml
+    {{ ORCA_LOCAL_ARCHIVE }} /workspace/orca.tar.xz
+
+%post
+    set -e
+
+    # Install system dependencies
+    apt-get update && \
+        apt-get install -y --no-install-recommends wget ca-certificates tar zip xz-utils curl jq && \
+        rm -rf /var/lib/apt/lists/*
+
+    # Set up conda environment and install SPyCCI
+    mamba env create -f /workspace/environment.yml
+    mamba clean -afy
+    conda run -n spycci python -m pip install --no-cache-dir -e /workspace
+    rm /workspace/environment.yml
+
+    # Install DFTB+ parameters
+    DFTBPLUS_PARAM_DIR=/opt/dftbplus/slakos
+    mkdir -p "${DFTBPLUS_PARAM_DIR}"
+    wget -q https://github.com/dftbparams/3ob/releases/download/v3.1.0/3ob-3-1.tar.xz -O /tmp/3ob.tar.xz
+    tar -xf /tmp/3ob.tar.xz -C "${DFTBPLUS_PARAM_DIR}"
+    rm /tmp/3ob.tar.xz
+
+    # Install ORCA
+    ORCA_TMP="/tmp/orca.tar.xz"
+    mkdir -p /opt/orca
+    tar -xf "${ORCA_TMP}" -C /opt/orca --strip-components=1 2>/dev/null || \
+        tar -xf "${ORCA_TMP}" -C /opt/orca
+    rm "${ORCA_TMP}"
+    chmod -R a+rx /opt/orca
+    find /opt/orca -maxdepth 2 -type f -name orca -perm -u+x -print -quit || { echo "ORCA binary not found in /opt/orca"; exit 1; }
+
+    # Install XTB
+    XTBHOME=/opt/xtb
+    wget -q https://github.com/grimme-lab/xtb/releases/download/v6.7.0/xtb-6.7.0-linux-x86_64.tar.xz
+    tar -xf xtb-6.7.0-linux-x86_64.tar.xz
+    mv xtb-dist "${XTBHOME}"
+    rm xtb-6.7.0-linux-x86_64.tar.xz
+
+    # Install CREST
+    CREST_BIN=/opt/crest
+    wget -q https://github.com/crest-lab/crest/releases/download/v3.0.2/crest-gnu-12-ubuntu-latest.tar.xz
+    tar -xf crest-gnu-12-ubuntu-latest.tar.xz
+    mv crest "${CREST_BIN}"
+    rm crest-gnu-12-ubuntu-latest.tar.xz
+    chmod +x "${CREST_BIN}/crest"
+
+    # Create user and set permissions
+    ORCA_ROOT=/opt/orca
+    useradd -m -s /bin/bash spyccitest || true
+    mkdir -p /workspace
+    chown -R spyccitest:spyccitest \
+        /workspace \
+        /opt/conda/envs/spycci \
+        "${ORCA_ROOT}" "${XTBHOME}" "${CREST_BIN}" "${DFTBPLUS_PARAM_DIR}"
+
+%environment
+    export CONDA_DEFAULT_ENV=spycci
+    export ORCA_ROOT=/opt/orca
+    export XTBHOME=/opt/xtb
+    export CREST_BIN=/opt/crest
+    export DFTBPLUS_PARAM_DIR=/opt/dftbplus/slakos
+    export PATH=/opt/orca:/opt/orca/bin:${XTBHOME}/bin:${CREST_BIN}:/opt/conda/envs/spycci/bin:${PATH}
+    export LD_LIBRARY_PATH=/opt/conda/envs/spycci/lib:/opt/orca/lib:${LD_LIBRARY_PATH}
+    export OMPI_MCA_plm=isolated
+    export OMPI_MCA_rmaps_base_oversubscribe=1
+    export OMPI_MCA_btl_vader_single_copy_mechanism=none
+    export OMPI_MCA_btl='^openib'
+    export PYTHONUNBUFFERED=1
+    export SPYCCI_VERSION_MATCH=minor
+
+%runscript
+    set -e
+    cd /workspace
+    if [ $# -eq 0 ]; then
+        set -- pytest -vvv --color=yes -ra --maxfail=0
+    fi
+    exec "$@"

--- a/apptainer.def
+++ b/apptainer.def
@@ -73,7 +73,7 @@ From: condaforge/mambaforge:24.9.2-0
     export CREST_BIN=/opt/crest
     export DFTBPLUS_PARAM_DIR=/opt/dftbplus/slakos
     export PATH=/opt/orca:/opt/orca/bin:${XTBHOME}/bin:${CREST_BIN}:/opt/conda/envs/spycci/bin:${PATH}
-    export LD_LIBRARY_PATH=/opt/conda/envs/spycci/lib:/opt/orca/lib:${LD_LIBRARY_PATH}
+    export LD_LIBRARY_PATH=/opt/conda/envs/spycci/lib:/opt/orca/lib
     export OMPI_MCA_plm=isolated
     export OMPI_MCA_rmaps_base_oversubscribe=1
     export OMPI_MCA_btl_vader_single_copy_mechanism=none

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -174,7 +174,7 @@ Here we provide the Singularity counterparts for the Docker commands explained a
 To build the container:
 
 ```shell
-singularity build --sandbox --build-arg ORCA_LOCAL_ARCHIVE=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz spycci.sif apptainer.def
+singularity build --build-arg ORCA_LOCAL_ARCHIVE=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz spycci.sif apptainer.def
 ```
 
 This will produce the `spycci.sif` container file, which can be run as:

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -129,7 +129,7 @@ By default, the `spycci` library requires an exact match for version dependency,
 
 To simplify the testing procedure, we provide a Dockerfile with all the required third-party software in the specific versions used for development. The only current exception is Orca, for which users need to provide their own archive, downloaded from the [FACCTs](https://www.faccts.de) website or the [Orca Forums](https://orcaforum.kofo.mpg.de/app.php/portal).
 
-To build the container, copy the `.tar.xz` archive with Orca (we recommend using version `6.1.0`) in the `SPyCCI` folder (the archive must be in the same location from which you launch the `docker build` command), and run:
+To build the container, copy the `.tar.xz` archive with Orca (we recommend using version `6.1.0-f.0`) in the `SPyCCI` folder (the archive must be in the same location from which you launch the `docker build` command), and run:
 
 :::{admonition} Note
 :class: info
@@ -163,4 +163,28 @@ It is also possible to run only a subset of tests and pass specific flags to the
 
 ```bash
 docker run --rm spycci:test pytest -vvv --color=yes tests/integration/test_xtb*
+```
+
+### Using Singularity instead of Docker
+
+In HPC environments, Docker is often not available as it requires root privileges for building images. In its stead, Singularity (or its open-source version Apptainer) are usually found. The concept is identical, meaning that a containerized image containing the necessary software stack is produced, and that can be used to ensure reproducibility during development or in production environment.
+
+Here we provide the Singularity counterparts for the Docker commands explained above. The explanations and comments can be used for either versions.
+
+To build the container:
+
+```shell
+singularity build --build-arg ORCA_LOCAL_ARCHIVE=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz spycci.sif apptainer.def
+```
+
+This will produce the `spycci.sif` file, which can be copied to HPC and run with:
+
+```shell
+singularity run spycci.sif
+```
+
+As with Docker, it is also possible to run only a subset of tests and pass specific flags to the `pytest` command:
+
+```bash
+singularity run spycci.sif pytest -vvv --color=yes tests/integration/test_xtb*
 ```

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -174,13 +174,13 @@ Here we provide the Singularity counterparts for the Docker commands explained a
 To build the container:
 
 ```shell
-singularity build --build-arg ORCA_LOCAL_ARCHIVE=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz spycci.sif apptainer.def
+singularity build --sandbox --build-arg ORCA_LOCAL_ARCHIVE=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz spycci.sif apptainer.def
 ```
 
-This will produce the `spycci.sif` file, which can be copied to HPC and run with:
+This will produce the **read-only** `spycci.sif` container file. When running, the work directory (usually the same directory containing the container file) must be bound to `/workspace` via the `--bind` flag:
 
 ```shell
-singularity run spycci.sif
+singularity run --bind ./:/workspace spycci.sif
 ```
 
 As with Docker, it is also possible to run only a subset of tests and pass specific flags to the `pytest` command:

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -165,6 +165,19 @@ It is also possible to run only a subset of tests and pass specific flags to the
 docker run --rm spycci:test pytest -vvv --color=yes tests/integration/test_xtb*
 ```
 
+Note that these test files are those included in the container image at build time. If you wish to use the container as a "software stack layer" during development, for example when writing new tests, you must bind the SPyCCI directory in which you are working to `/workspace`, so that the container is able to see the "updated" test versions:
+
+```bash
+docker run --mount type=bind,src=.,dst=/workspace --rm spycci:test pytest -vvv --color=yes tests/
+```
+
+With this command, bind path will overwrite the `/workspace` files with the ones on your filesystem and the container will work on those, instead of the ones included at build time.
+
+:::{admonition} Bind Paths
+:class: warning
+Modifications to bind paths are **permanent** and occur on the actual filesystem running the container.
+:::
+
 ### Using Singularity instead of Docker
 
 In HPC environments, Docker is often not available as it requires root privileges for building images. In its stead, Singularity (or its open-source version Apptainer) are usually found. The concept is identical, meaning that a containerized image containing the necessary software stack is produced, and that can be used to ensure reproducibility during development or in production environment.
@@ -185,18 +198,14 @@ singularity run spycci.sif
 
 :::{admonition} Bind Paths
 :class: warning
-Singularity container are by default read-only, therefore calculations will normally fail as the container cannot write the results anywhere. For normal operations, the current directory should be mapped to `/workspace`; it is also recommended to mount the default scratch folder for your HPC environment. The following command runs the SPyCCI Singularity container, with write access to both the current directory and `/scratch_local`.
+Singularity container are by default read-only, therefore calculations will normally fail as the container cannot write the results anywhere. For normal operations, the current directory should be mapped to `/workspace` similarly to Docker; it is also recommended to mount the default scratch folder for your HPC environment as some functions use that as a temporary work directory. 
+:::
+
+The following command runs the SPyCCI Singularity container, with write access to both the current directory and `/scratch_local`.
 
 ```shell
 singularity run --bind ./:/workspace,/scratch_local spycci.sif
 ```
-
-:::
-
-:::{admonition} Bind Paths
-:class: warning
-Be aware that unlike Docker, modifications to bind paths are **permanent** and occur on the actual filesystem running the container.
-:::
 
 As with Docker, it is also possible to run only a subset of tests and pass specific flags to the `pytest` command:
 

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -177,14 +177,29 @@ To build the container:
 singularity build --sandbox --build-arg ORCA_LOCAL_ARCHIVE=orca-6.1.0-f.0_linux_x86-64_openmpi41.tar.xz spycci.sif apptainer.def
 ```
 
-This will produce the **read-only** `spycci.sif` container file. When running, the work directory (usually the same directory containing the container file) must be bound to `/workspace` via the `--bind` flag:
+This will produce the `spycci.sif` container file, which can be run as:
 
 ```shell
-singularity run --bind ./:/workspace spycci.sif
+singularity run spycci.sif
 ```
+
+:::{admonition} Bind Paths
+:class: warning
+Singularity container are by default read-only, therefore calculations will normally fail as the container cannot write the results anywhere. For normal operations, the current directory should be mapped to `/workspace`; it is also recommended to mount the default scratch folder for your HPC environment. The following command runs the SPyCCI Singularity container, with write access to both the current directory and `/scratch_local`.
+
+```shell
+singularity run --bind ./:/workspace,/scratch_local spycci.sif
+```
+
+:::
+
+:::{admonition} Bind Paths
+:class: warning
+Be aware that unlike Docker, modifications to bind paths are **permanent** and occur on the actual filesystem running the container.
+:::
 
 As with Docker, it is also possible to run only a subset of tests and pass specific flags to the `pytest` command:
 
 ```bash
-singularity run spycci.sif pytest -vvv --color=yes tests/integration/test_xtb*
+singularity run --bind ./:/workspace,/scratch_local spycci.sif pytest -vvv --color=yes tests/integration/test_xtb*
 ```


### PR DESCRIPTION
This PR adds support for building Singularity/Apptainer containers for HPC use.

In HPC environments, Docker is often not available as it requires root privileges for building/running containers. In its place, [Singularity](https://docs.sylabs.io/guides/3.5/user-guide/introduction.html) (or its open-source version [Apptainer](https://apptainer.org/)) are used.

While it is technically possible to convert a Docker image to Singularity, it is often clunky and error-prone, so a dedicated Singularity recipe is recommended.

The `apptainer.def` file is created, with the Singularity version of the Dockerfile recipe we're using to build the Docker container.

Incidentally, I've also tweaked the current Dockerfile to reduce file size, I previously copied everything from the work directory to `/workspace`, which also included eventual stray files. Now only the necessary SPyCCI files are copied to the image file.

Some more information is added to the documentation, including how to build/run Singularity container, as well as how to bind local folders to the Docker container for use during development (so you don't have to rebuild the image everytime you write a new test...)